### PR TITLE
Update parent and dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.532.2</version>
+        <version>1.580.1</version>
     </parent>
-    <properties>
-        <maven-hpi-plugin.version>1.99</maven-hpi-plugin.version>
-    </properties>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plain-credentials</artifactId>
     <version>1.1-SNAPSHOT</version>
@@ -43,7 +40,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>1.9.4</version>
+            <version>1.20</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Parent update supersedes the need for something like https://github.com/jenkinsci/credentials-plugin/pull/20.

As to the minimum Jenkins version, the only use case for this plugin that I know of is to be bound,  but that requires 1.580.1+ anyway as of https://github.com/jenkinsci/credentials-binding-plugin/pull/2.

@reviewbybees