### PR TITLE
[JENKINS-27391] Properly display "Secret text" credentials name

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/plaincredentials/StringCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/plaincredentials/StringCredentials.java
@@ -29,6 +29,9 @@ import com.cloudbees.plugins.credentials.NameWith;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import hudson.Util;
 import hudson.util.Secret;
+
+import java.util.UUID;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -47,9 +50,24 @@ public interface StringCredentials extends StandardCredentials {
 
         @Override public String getName(StringCredentials c) {
             String description = Util.fixEmptyAndTrim(c.getDescription());
-            return Messages.StringCredentials_some_text() + (description != null ? " (" + description + ")" : "");
+            String ID = c.getId();
+            return description != null ? description : (!isUUID(ID) ? ID : Messages.StringCredentials_string_credentials());
         }
 
+        /**
+         * Checks whether an ID has UUID format
+         * 
+         * @param ID the ID to check
+         * @return true if the ID has UUID format. False otherwise.
+         */
+        private static boolean isUUID(String ID) {
+            try {
+                UUID.fromString(ID);
+                return true;
+            } catch (IllegalArgumentException ex) {
+                return false;
+            }
+        }
     }
 
 }

--- a/src/main/resources/org/jenkinsci/plugins/plaincredentials/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/plaincredentials/Messages.properties
@@ -1,1 +1,1 @@
-StringCredentials.some_text=some text
+StringCredentials.string_credentials=Secret text


### PR DESCRIPTION
[JENKINS-27391](https://issues.jenkins-ci.org/browse/JENKINS-27391)

Properly display secret text credentials name.

If four _Secret texts_ credentials are created configured as follows:

1. Some description, auto-generated ID
2. No description, auto-generated ID
3. Some description, custom ID
4. Blank description, custom ID

This is how it looks at the moment:

<img width="1011" alt="screen shot 2016-05-17 at 13 02 42" src="https://cloud.githubusercontent.com/assets/10669883/15320273/e2418a32-1c2f-11e6-9839-eae595e42657.png">

This is how it looks after the change in this PR:

<img width="1020" alt="screen shot 2016-05-17 at 12 59 51" src="https://cloud.githubusercontent.com/assets/10669883/15320278/e9a84d1a-1c2f-11e6-9841-940c58a6fa0c.png">

Logic is, if there is a description, the description is used. If there is no description and the ID was set by the user (ID does not have UUID format), the ID is used. Otherwise, "Secret text" is displayed (instead of "some text")

@reviewbybees esp. @jglick 
