### PR TITLE
[JENKINS-42437] Remove use of deprecated constructors in tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/plaincredentials/BaseTest.java
+++ b/src/test/java/org/jenkinsci/plugins/plaincredentials/BaseTest.java
@@ -7,6 +7,7 @@ import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 
+import com.cloudbees.plugins.credentials.SecretBytes;
 import org.apache.commons.fileupload.disk.DiskFileItem;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl;
@@ -22,7 +23,6 @@ import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
-import com.trilead.ssh2.crypto.Base64;
 
 import hudson.security.ACL;
 import hudson.util.Secret;
@@ -56,7 +56,7 @@ public class BaseTest {
     public void secretFileBaseTest() throws IOException, URISyntaxException {
         DiskFileItem fileItem = createEmptyFileItem();
         
-        FileCredentialsImpl credential = new FileCredentialsImpl(CredentialsScope.GLOBAL, CRED_ID, "Test Secret file", fileItem, "keys.txt", Base64.encode(fileItem.get()).toString());
+        FileCredentialsImpl credential = new FileCredentialsImpl(CredentialsScope.GLOBAL, CRED_ID, "Test Secret file", fileItem, "keys.txt", SecretBytes.fromBytes(fileItem.get()));
         FileCredentialsImpl updatedCredential = new FileCredentialsImpl(credential.getScope(), UPDATED_CRED_ID, credential.getDescription(), fileItem, credential.getFileName(), credential.getSecretBytes());
         testCreateUpdateDelete(credential, updatedCredential);
     }

--- a/src/test/java/org/jenkinsci/plugins/plaincredentials/BaseTest.java
+++ b/src/test/java/org/jenkinsci/plugins/plaincredentials/BaseTest.java
@@ -23,6 +23,7 @@ import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import com.trilead.ssh2.crypto.Base64;
 
 import hudson.security.ACL;
 import hudson.util.Secret;
@@ -54,9 +55,25 @@ public class BaseTest {
     
     @Test
     public void secretFileBaseTest() throws IOException, URISyntaxException {
+        secretFileTest(false);
+    }
+
+    @Test
+    public void secretFileBaseTestWithDeprecatedCtor() throws IOException, URISyntaxException {
+        secretFileTest(true);
+    }
+
+    private void secretFileTest(boolean useDeprecatedConstructor) throws IOException, URISyntaxException {
         DiskFileItem fileItem = createEmptyFileItem();
-        
-        FileCredentialsImpl credential = new FileCredentialsImpl(CredentialsScope.GLOBAL, CRED_ID, "Test Secret file", fileItem, "keys.txt", SecretBytes.fromBytes(fileItem.get()));
+
+        FileCredentialsImpl credential;
+
+        if (useDeprecatedConstructor) {
+            credential = new FileCredentialsImpl(CredentialsScope.GLOBAL, CRED_ID, "Test Secret file", fileItem, "keys.txt", Base64.encode(fileItem.get()).toString());
+        } else {
+            credential = new FileCredentialsImpl(CredentialsScope.GLOBAL, CRED_ID, "Test Secret file", fileItem, "keys.txt", SecretBytes.fromBytes(fileItem.get()));
+        }
+
         FileCredentialsImpl updatedCredential = new FileCredentialsImpl(credential.getScope(), UPDATED_CRED_ID, credential.getDescription(), fileItem, credential.getFileName(), credential.getSecretBytes());
         testCreateUpdateDelete(credential, updatedCredential);
     }

--- a/src/test/java/org/jenkinsci/plugins/plaincredentials/FileCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/plaincredentials/FileCredentialsTest.java
@@ -24,6 +24,7 @@
 package org.jenkinsci.plugins.plaincredentials;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SecretBytes;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemHeaders;
 import org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl;
@@ -46,7 +47,7 @@ public class FileCredentialsTest {
     @Test(expected = IllegalArgumentException.class)
     @Issue("JENKINS-30926")
     public void shouldThrowAnExceptionIfFileNameIsBlank() throws IOException {
-        new FileCredentialsImpl(CredentialsScope.GLOBAL, "1", "", new StubFileItem(), "", "");
+        new FileCredentialsImpl(CredentialsScope.GLOBAL, "1", "", new StubFileItem(), "", SecretBytes.fromString(""));
     }
 
     private class StubFileItem implements FileItem {


### PR DESCRIPTION
[JENKINS-42437](https://issues.jenkins-ci.org/browse/JENKINS-42437)

BaseTest and FileCredentialsTest are using deprecated FileCredentialsImpl contructors.

@reviewbybees @stephenc @jglick 