### PR TITLE
allow file to be null for use in CasC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,19 @@
       <artifactId>credentials</artifactId>
       <version>2.1.5</version>
     </dependency>
+
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>configuration-as-code-support</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.5</version>
+      <version>2.1.16</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/plaincredentials/impl/FileCredentialsImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/plaincredentials/impl/FileCredentialsImpl.java
@@ -78,6 +78,7 @@ public final class FileCredentialsImpl extends BaseStandardCredentials implement
      */
     @Nonnull
     private final SecretBytes secretBytes;
+
     /**
      * The legacy encrypted version of the secret bytes.
      */
@@ -137,10 +138,10 @@ public final class FileCredentialsImpl extends BaseStandardCredentials implement
      */
     @DataBoundConstructor
     public FileCredentialsImpl(@CheckForNull CredentialsScope scope, @CheckForNull String id,
-                               @CheckForNull String description, @Nonnull FileItem file, @CheckForNull String fileName,
+                               @CheckForNull String description, @CheckForNull FileItem file, @CheckForNull String fileName,
                                @CheckForNull SecretBytes secretBytes) throws IOException {
         super(scope, id, description);
-        String name = file.getName();
+        String name = file != null ? file.getName() : "";
         if (name.length() > 0) {
             this.fileName = name.replaceFirst("^.+[/\\\\]", "");
             this.secretBytes = SecretBytes.fromBytes(file.get());

--- a/src/test/java/org/jenkinsci/plugins/plaincredentials/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/plaincredentials/ConfigurationAsCodeTest.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.plaincredentials;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.SecretBytes;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import hudson.security.ACL;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class ConfigurationAsCodeTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void should_configure_file_credentials() throws Exception {
+        SecretBytes.decrypt(null); // force class loading to get Stapler converter registered
+        ConfigurationAsCode.get().configure(getClass().getResource("ConfigurationAsCode.yaml").toString());
+        final FileCredentials credentials = CredentialsMatchers.firstOrNull(
+                CredentialsProvider.lookupCredentials(FileCredentials.class, j.jenkins, ACL.SYSTEM, (DomainRequirement) null),
+                CredentialsMatchers.withId("secret-file"));
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("Some secret file", credentials.getDescription());
+        Assert.assertEquals("my-secret-file", credentials.getFileName());
+        Assert.assertEquals("FOO_BAR", IOUtils.toString(credentials.getContent()));
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/plaincredentials/ConfigurationAsCode.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/plaincredentials/ConfigurationAsCode.yaml
@@ -1,0 +1,12 @@
+credentials:
+  system:
+    domainCredentials:
+    # global credentials
+    - credentials:
+      - file:
+          id: secret-file
+          scope: SYSTEM
+          description: "Some secret file"
+          fileName: my-secret-file
+          # FOO_BAR base64 encoded
+          secretBytes: Rk9PX0JBUg==


### PR DESCRIPTION
requirement for `file` to be non-null just to get a name prevents simple use of FileCredentialsImpl in Configuration-as-Code.

deployed as plain-credentials-1.5-20180703.101522-1

See https://github.com/jenkinsci/configuration-as-code-plugin/pull/317