### PR TITLE
FEAT: allow for null file for CasC support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,20 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.5</version>
+      <version>2.1.16</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>configuration-as-code-support</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/test/java/org/jenkinsci/plugins/plaincredentials/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/plaincredentials/ConfigurationAsCodeTest.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.plaincredentials;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import hudson.security.ACL;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ConfigurationAsCodeTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void setup() throws Exception {
+        ConfigurationAsCode.get().configure(readFile("casc_fileCredentials.yml"));
+    }
+
+    @Test
+    public void should_configure_file_credentials() throws Exception {
+        FileCredentials credentials = lookupCredentials("secret-file");
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("secret-file.txt", credentials.getFileName());
+        Assert.assertEquals("secret-file", credentials.getDescription());
+        Assert.assertEquals("Hello World!", IOUtils.toString(credentials.getContent()));
+    }
+
+    private String readFile(String s) {
+        return getClass().getResource(s).toString();
+    }
+
+    private FileCredentials lookupCredentials(String id) {
+        return CredentialsMatchers.firstOrNull(
+                CredentialsProvider.lookupCredentials(FileCredentials.class, j.jenkins, ACL.SYSTEM, (DomainRequirement) null),
+                CredentialsMatchers.withId(id));
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/plaincredentials/casc_fileCredentials.yml
+++ b/src/test/resources/org/jenkinsci/plugins/plaincredentials/casc_fileCredentials.yml
@@ -1,0 +1,10 @@
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - file:
+              id: "secret-file"
+              scope: "SYSTEM"
+              description: "secret-file"
+              fileName: "secret-file.txt"
+              secretBytes: "SGVsbG8gV29ybGQh"


### PR DESCRIPTION
@jglick This is follow up to https://github.com/jenkinsci/plain-credentials-plugin/pull/11. 