### PR TITLE
Remove trilead from credentials test

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/plaincredentials/BaseTest.java
+++ b/src/test/java/org/jenkinsci/plugins/plaincredentials/BaseTest.java
@@ -4,6 +4,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
@@ -23,7 +25,6 @@ import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
-import com.trilead.ssh2.crypto.Base64;
 
 import hudson.security.ACL;
 import hudson.util.Secret;
@@ -69,7 +70,7 @@ public class BaseTest {
         FileCredentialsImpl credential;
 
         if (useDeprecatedConstructor) {
-            credential = new FileCredentialsImpl(CredentialsScope.GLOBAL, CRED_ID, "Test Secret file", fileItem, "keys.txt", Base64.encode(fileItem.get()).toString());
+            credential = new FileCredentialsImpl(CredentialsScope.GLOBAL, CRED_ID, "Test Secret file", fileItem, "keys.txt", Arrays.toString(Base64.getEncoder().encode(fileItem.get())));
         } else {
             credential = new FileCredentialsImpl(CredentialsScope.GLOBAL, CRED_ID, "Test Secret file", fileItem, "keys.txt", SecretBytes.fromBytes(fileItem.get()));
         }


### PR DESCRIPTION
Fixes the current test failure on https://github.com/jenkinsci/bom/pull/110

Could we please get a release so that we can incorporate it into the bom