### PR TITLE
Upgrade to use jcasc test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.29</version>
+    <version>3.56</version>
     <relativePath />
   </parent>
 
@@ -54,9 +54,9 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
-    <configuration-as-code-plugin.version>1.3</configuration-as-code-plugin.version>
+    <configuration-as-code-plugin.version>1.35</configuration-as-code-plugin.version>
   </properties>
 
   <repositories>
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.16</version>
+      <version>2.2.0</version>
     </dependency>
 
     <dependency>
@@ -87,7 +87,7 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
-      <artifactId>configuration-as-code-support</artifactId>
+      <artifactId>test-harness</artifactId>
       <version>${configuration-as-code-plugin.version}</version>
       <scope>test</scope>
     </dependency>
@@ -102,6 +102,7 @@
           <loggers>
             <org.jenkinsci.plugins.plaincredentials>FINE</org.jenkinsci.plugins.plaincredentials>
           </loggers>
+          <minimumJavaVersion>1.8</minimumJavaVersion>
         </configuration>
       </plugin>
     </plugins>

--- a/src/test/java/org/jenkinsci/plugins/plaincredentials/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/plaincredentials/ConfigurationAsCodeTest.java
@@ -4,12 +4,14 @@ import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import hudson.security.ACL;
-import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -17,17 +19,17 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class ConfigurationAsCodeTest {
 
     @Rule
-    public JenkinsRule j = new JenkinsRule();
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
 
     @Test
+    @ConfiguredWithCode("ConfigurationAsCode.yaml")
     public void should_configure_file_credentials() throws Exception {
-        ConfigurationAsCode.get().configure(getClass().getResource("ConfigurationAsCode.yaml").toString());
-        final FileCredentials credentials = CredentialsMatchers.firstOrNull(
+        FileCredentials credentials = CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(FileCredentials.class, j.jenkins, ACL.SYSTEM, (DomainRequirement) null),
                 CredentialsMatchers.withId("secret-file"));
-        Assert.assertNotNull(credentials);
-        Assert.assertEquals("Some secret file", credentials.getDescription());
-        Assert.assertEquals("my-secret-file", credentials.getFileName());
-        Assert.assertEquals("FOO_BAR", IOUtils.toString(credentials.getContent()));
+        assertNotNull(credentials);
+        assertEquals("Some secret file", credentials.getDescription());
+        assertEquals("my-secret-file", credentials.getFileName());
+        assertEquals("FOO_BAR", IOUtils.toString(credentials.getContent()));
     }
 }


### PR DESCRIPTION
Support plugin is long dead

New credentials plugin version requires 2.138.4

New plugin-pom requires `minimumJavaVersion` if you're overriding its config, (not entirely sure if the override is still needed though.

Bit of modernising done in the jcasc test while I was here