### PR TITLE
Allow for job-dsl credentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/plaincredentials/impl/StringCredentialsImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/plaincredentials/impl/StringCredentialsImpl.java
@@ -39,7 +39,12 @@ public final class StringCredentialsImpl extends BaseStandardCredentials impleme
 
     private final @Nonnull Secret secret;
 
-    @DataBoundConstructor public StringCredentialsImpl(@CheckForNull CredentialsScope scope, @CheckForNull String id, @CheckForNull String description, @Nonnull Secret secret) {
+    @DataBoundConstructor public StringCredentialsImpl(@CheckForNull CredentialsScope scope, @CheckForNull String id, @CheckForNull String description, @Nonnull String secret) {
+        super(scope, id, description);
+        this.secret = Secret.fromString(secret);
+    }
+
+    public StringCredentialsImpl(@CheckForNull CredentialsScope scope, @CheckForNull String id, @CheckForNull String description, @Nonnull Secret secret) {
         super(scope, id, description);
         this.secret = secret;
     }

--- a/src/test/java/org/jenkinsci/plugins/plaincredentials/BaseTest.java
+++ b/src/test/java/org/jenkinsci/plugins/plaincredentials/BaseTest.java
@@ -48,9 +48,16 @@ public class BaseTest {
     }
     
     @Test
+    public void textBaseTest() throws IOException {
+        StringCredentialsImpl credential = new StringCredentialsImpl(CredentialsScope.GLOBAL, CRED_ID, "Test Secret Text", "password");
+        StringCredentialsImpl updatedCredential = new StringCredentialsImpl(credential.getScope(), UPDATED_CRED_ID, credential.getDescription(), credential.getSecret().getPlainText());
+        testCreateUpdateDelete(credential, updatedCredential);
+    }
+
+    @Test
     public void secretTextBaseTest() throws IOException {
         StringCredentialsImpl credential = new StringCredentialsImpl(CredentialsScope.GLOBAL, CRED_ID, "Test Secret Text", Secret.fromString("password"));
-        StringCredentialsImpl updatedCredential = new StringCredentialsImpl(credential.getScope(), UPDATED_CRED_ID, credential.getDescription(), credential.getSecret()); 
+        StringCredentialsImpl updatedCredential = new StringCredentialsImpl(credential.getScope(), UPDATED_CRED_ID, credential.getDescription(), credential.getSecret());
         testCreateUpdateDelete(credential, updatedCredential);
     }
     


### PR DESCRIPTION
Fixed https://issues.jenkins.io/browse/JENKINS-59971

As far as I can tell there is no backwards incompatibilities here. I've done some manual testing, though as I'm not very familiar with Jenkins code, I might be mistaken.

If this is not the right approach, please let me know, happy to make changes to your liking.

cc @daspilker 