### PR TITLE
use different icons for "secret text" and "username with password"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/plaincredentials/impl/StringCredentialsImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/plaincredentials/impl/StringCredentialsImpl.java
@@ -57,6 +57,11 @@ public final class StringCredentialsImpl extends BaseStandardCredentials impleme
             return Messages.StringCredentialsImpl_secret_text();
         }
 
+        @Override
+        public String getIconClassName(){
+            return "symbol-details";
+        }
+
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/plaincredentials/impl/StringCredentialsImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/plaincredentials/impl/StringCredentialsImpl.java
@@ -57,6 +57,9 @@ public final class StringCredentialsImpl extends BaseStandardCredentials impleme
             return Messages.StringCredentialsImpl_secret_text();
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public String getIconClassName(){
             return "symbol-details";


### PR DESCRIPTION
See [JENKINS-75770](https://issues.jenkins.io/browse/JENKINS-75700)

This change is to use new icon for the **Secret Text** credential in `plain-credential-plugin`



Changes I did:

I added `getIconClassName` override method in `StringCredentialsImpl.java` class, which now returns the new [details.svg](https://github.com/jenkinsci/jenkins/blob/master/war/src/main/resources/images/symbols/details.svg) icon for any secret text added via Credentials in Jenkins.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
